### PR TITLE
Fix/timezone asia tokyo clean

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ VOLUME ["/data"]
 
 # DB パスを環境変数で渡す（entrypoint.sh でも参照）
 ENV DB_PATH=/data/numbers.db
+ENV TZ=Asia/Tokyo
 
 EXPOSE 8000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     # devices:
     #   - /dev/bus/usb:/dev/bus/usb   # USBプリンター（Linuxホストのみ有効）
     environment:
+      - TZ=Asia/Tokyo
       - PRINTER_VID=0x04b8
       - PRINTER_PID=0x0e20
     restart: unless-stopped

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -58,9 +58,9 @@ curl -s http://localhost:8000/display_data
 
 ```bash
 pip install -r requirements.txt
-python init_db.py                                   # 初回のみ（DB初期化）
-python app.py                                       # 開発サーバー
-waitress-serve --host=0.0.0.0 --port=8000 app:app   # 本番相当（Waitress）
+python init_db.py                                                   # 初回のみ（DB初期化）
+TZ=Asia/Tokyo python app.py                                         # 開発サーバー
+TZ=Asia/Tokyo waitress-serve --host=0.0.0.0 --port=8000 app:app     # 本番相当（Waitress）
 ```
 
 > Windows でレシートプリンターを使う場合は `pip install pywin32` も必要（`requirements.txt` には含まない）。


### PR DESCRIPTION
## 概要

Issue #6 で確認されたタイムゾーン差異への PATCH 対応として、Docker 環境および非 Docker 環境の起動例に `TZ=Asia/Tokyo` を明示します。

## 変更内容

- `Dockerfile` に `ENV TZ=Asia/Tokyo` を追加
- `docker-compose.yml` の `environment` に `TZ=Asia/Tokyo` を追加
- `docs/DEVELOPMENT.md` の非 Docker 起動例に `TZ=Asia/Tokyo` を明記

## 目的

実行環境によってタイムゾーン解釈が変わることを避け、芽室町での運用前提に合わせて日本時間で動作することを明示します。

## 動作確認

- ドキュメント修正および環境変数追加のみ
- アプリケーションロジックの変更なし

Refs #6