### PR TITLE
発券時に印刷結果を明示し、短時間の連打を抑止する

### DIFF
--- a/app.py
+++ b/app.py
@@ -106,9 +106,9 @@ def _print_linux(data):
         dev.write(1, data)
 
 def print_ticket(category, button_text, number, timestamp_str):
-    """レシートプリンターにチケットを印刷する。カテゴリDは印刷しない。"""
+    """レシートプリンターにチケットを印刷する。カテゴリDは印刷せず成功扱いにする。"""
     if category == 'D':
-        return
+        return True
     try:
         import sys
         encoding = 'cp932' if sys.platform == 'win32' else 'utf-8'
@@ -118,8 +118,10 @@ def print_ticket(category, button_text, number, timestamp_str):
         else:
             _print_linux(data)
         print(f'[print_ticket] 印刷完了: カテゴリ={category} 番号={number}')
+        return True
     except Exception as e:
         print(f'[print_ticket] error: {e}')
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -255,9 +257,13 @@ def get_next_number():
         return jsonify({'error': 'Internal server error'}), 500
 
     # DB書き込み成功後に印刷（失敗しても発券結果は返す）
-    print_ticket(category, button_text or '', new_number, timestamp or '')
+    print_ok = print_ticket(category, button_text or '', new_number, timestamp or '')
 
-    return jsonify({'category': category, 'next_number': new_number})
+    return jsonify({
+        'category': category,
+        'next_number': new_number,
+        'print_ok': print_ok,
+    })
 
 
 @app.route('/start_processing', methods=['POST'])

--- a/docs/audit/CODEX_DOCKER_VERIFICATION.md
+++ b/docs/audit/CODEX_DOCKER_VERIFICATION.md
@@ -1,0 +1,83 @@
+# Codex Cloud Docker verification
+
+Date: 2026-06-21 (UTC)
+Repository: `to4kawa/MADO-queue`
+Scope: Codex Cloud environment capability check only. Repository files were not changed during the Docker capability probes.
+
+## Summary
+
+Codex Cloud cannot currently be used for `docker build` or `docker compose up` verification in this repository.
+
+The previous baseline audit recorded Docker verification as unavailable because the `docker` executable was not present. This follow-up confirmed that Docker CLI and the `dockerd` binary can be installed, but Docker daemon startup still fails because the Codex Cloud execution environment does not allow the low-level operations required by Docker daemon.
+
+## Result
+
+- OS: Ubuntu 24.04.4 LTS (Noble Numbat)
+- User: `root`
+- `apt-get update`: succeeded
+- `apt-get install -y docker.io`: succeeded
+- `docker --version`: succeeded
+- `dockerd --version`: succeeded
+- `docker info`: failed
+- `/var/run/docker.sock`: unavailable
+- `docker compose version`: unavailable in the checked environment
+- Repository file changes during probe: none
+- `git status --short`: empty
+
+## Failure mode
+
+Manual `dockerd` startup failed during bridge network / iptables initialization.
+
+Representative error:
+
+```text
+failed to start daemon: Error initializing network controller:
+error obtaining controller instance:
+failed to register "bridge" driver:
+failed to create NAT chain DOCKER:
+iptables ... Permission denied
+```
+
+Because the process was running as `root`, this is not ordinary user permission failure. It is treated as an execution-environment limitation, likely involving container capabilities, cgroups, iptables, network namespace, or related kernel-level restrictions.
+
+The environment also appeared to expose `/sys` and `/sys/fs/cgroup` as read-only, which is consistent with Docker daemon startup being unavailable in this environment.
+
+## Classification
+
+- Docker CLI: installable
+- `dockerd` binary: installable
+- Docker daemon: not usable
+- Docker socket: not usable
+- Docker Compose: not usable for repository verification in this environment
+- `docker build` / `docker compose up`: not executable in Codex Cloud for this repository
+
+## Impact on MADO-queue verification
+
+The following checks cannot be completed in Codex Cloud:
+
+- `docker build`
+- `docker compose build`
+- `docker compose up`
+- HTTP smoke tests against a containerized service
+- In-container timezone checks such as `date`, Python `datetime.now()`, and SQLite `localtime`
+
+## What can still be verified in Codex Cloud
+
+Codex Cloud can still be used for non-Docker checks, including:
+
+- Python unit tests
+- Static review of `Dockerfile`
+- Static review of `docker-compose.yml`
+- Review of timezone-sensitive application code
+- Python / SQLite timezone behavior outside Docker
+
+## Recommended follow-up
+
+Docker startup verification should be rerun in an environment that provides a usable Docker daemon, such as:
+
+- a local development machine
+- a CI runner with Docker daemon enabled
+- an environment with Docker socket mount enabled
+- a privileged Docker-in-Docker environment
+
+If Docker-related changes are proposed from Codex Cloud, mark Docker build/start verification as not executed and describe the verification as static review only.

--- a/docs/audit/CODEX_DOCKER_VERIFICATION.md
+++ b/docs/audit/CODEX_DOCKER_VERIFICATION.md
@@ -1,34 +1,34 @@
-# Codex Cloud Docker verification
+# Codex Cloud Docker 検証
 
-Date: 2026-06-21 (UTC)
-Repository: `to4kawa/MADO-queue`
-Scope: Codex Cloud environment capability check only. Repository files were not changed during the Docker capability probes.
+日付: 2026-06-21 (UTC)
+リポジトリ: `to4kawa/MADO-queue`
+範囲: Codex Cloud 環境での実行可否確認のみ。Docker 実行可否の調査中に、リポジトリ内のファイルは変更していません。
 
-## Summary
+## 概要
 
-Codex Cloud cannot currently be used for `docker build` or `docker compose up` verification in this repository.
+現時点では、このリポジトリの `docker build` や `docker compose up` の検証に Codex Cloud は使用できません。
 
-The previous baseline audit recorded Docker verification as unavailable because the `docker` executable was not present. This follow-up confirmed that Docker CLI and the `dockerd` binary can be installed, but Docker daemon startup still fails because the Codex Cloud execution environment does not allow the low-level operations required by Docker daemon.
+前回のベースライン監査では、`docker` 実行ファイルが存在しないため Docker 検証不可としていました。今回の追加確認では、Docker CLI と `dockerd` バイナリ自体はインストールできることを確認しました。ただし、Codex Cloud の実行環境では Docker デーモンが必要とする低レベル操作が許可されていないため、Docker デーモンの起動は失敗します。
 
-## Result
+## 結果
 
 - OS: Ubuntu 24.04.4 LTS (Noble Numbat)
 - User: `root`
-- `apt-get update`: succeeded
-- `apt-get install -y docker.io`: succeeded
-- `docker --version`: succeeded
-- `dockerd --version`: succeeded
-- `docker info`: failed
-- `/var/run/docker.sock`: unavailable
-- `docker compose version`: unavailable in the checked environment
-- Repository file changes during probe: none
-- `git status --short`: empty
+- `apt-get update`: 成功
+- `apt-get install -y docker.io`: 成功
+- `docker --version`: 成功
+- `dockerd --version`: 成功
+- `docker info`: 失敗
+- `/var/run/docker.sock`: 利用不可
+- `docker compose version`: 確認した環境では利用不可
+- 調査中のリポジトリファイル変更: なし
+- `git status --short`: 空
 
-## Failure mode
+## 失敗モード
 
-Manual `dockerd` startup failed during bridge network / iptables initialization.
+手動での `dockerd` 起動は、bridge network / iptables の初期化中に失敗しました。
 
-Representative error:
+代表的なエラー:
 
 ```text
 failed to start daemon: Error initializing network controller:
@@ -38,46 +38,46 @@ failed to create NAT chain DOCKER:
 iptables ... Permission denied
 ```
 
-Because the process was running as `root`, this is not ordinary user permission failure. It is treated as an execution-environment limitation, likely involving container capabilities, cgroups, iptables, network namespace, or related kernel-level restrictions.
+プロセスは `root` で実行されていたため、これは通常のユーザー権限不足ではありません。コンテナ capabilities、cgroups、iptables、network namespace、または関連するカーネルレベルの制限を含む、実行環境側の制約として扱います。
 
-The environment also appeared to expose `/sys` and `/sys/fs/cgroup` as read-only, which is consistent with Docker daemon startup being unavailable in this environment.
+また、この環境では `/sys` と `/sys/fs/cgroup` が読み取り専用として見えていました。この状態は、Docker デーモンを起動できない環境であることと整合します。
 
-## Classification
+## 分類
 
-- Docker CLI: installable
-- `dockerd` binary: installable
-- Docker daemon: not usable
-- Docker socket: not usable
-- Docker Compose: not usable for repository verification in this environment
-- `docker build` / `docker compose up`: not executable in Codex Cloud for this repository
+- Docker CLI: インストール可能
+- `dockerd` バイナリ: インストール可能
+- Docker デーモン: 使用不可
+- Docker socket: 使用不可
+- Docker Compose: この環境ではリポジトリ検証に使用不可
+- `docker build` / `docker compose up`: このリポジトリでは Codex Cloud 上で実行不可
 
-## Impact on MADO-queue verification
+## MADO-queue 検証への影響
 
-The following checks cannot be completed in Codex Cloud:
+Codex Cloud では、以下の確認は完了できません。
 
 - `docker build`
 - `docker compose build`
 - `docker compose up`
-- HTTP smoke tests against a containerized service
-- In-container timezone checks such as `date`, Python `datetime.now()`, and SQLite `localtime`
+- コンテナ化されたサービスに対する HTTP smoke test
+- コンテナ内でのタイムゾーン確認。例: `date`、Python `datetime.now()`、SQLite `localtime`
 
-## What can still be verified in Codex Cloud
+## Codex Cloud で引き続き確認できること
 
-Codex Cloud can still be used for non-Docker checks, including:
+Codex Cloud では、Docker を使わない以下の確認は引き続き実施できます。
 
 - Python unit tests
-- Static review of `Dockerfile`
-- Static review of `docker-compose.yml`
-- Review of timezone-sensitive application code
-- Python / SQLite timezone behavior outside Docker
+- `Dockerfile` の静的レビュー
+- `docker-compose.yml` の静的レビュー
+- タイムゾーン依存のアプリケーションコードレビュー
+- Docker 外での Python / SQLite タイムゾーン挙動確認
 
-## Recommended follow-up
+## 推奨される後続確認
 
-Docker startup verification should be rerun in an environment that provides a usable Docker daemon, such as:
+Docker の起動確認は、Docker デーモンを使用できる環境で再実行してください。例:
 
-- a local development machine
-- a CI runner with Docker daemon enabled
-- an environment with Docker socket mount enabled
-- a privileged Docker-in-Docker environment
+- ローカル開発環境
+- Docker デーモンが有効な CI runner
+- Docker socket mount が有効な環境
+- privileged Docker-in-Docker 環境
 
-If Docker-related changes are proposed from Codex Cloud, mark Docker build/start verification as not executed and describe the verification as static review only.
+Codex Cloud から Docker 関連の変更を提案する場合は、Docker build/start の検証は未実施であることを明記し、検証内容は静的レビューのみとして記録してください。

--- a/static/script.js
+++ b/static/script.js
@@ -35,11 +35,24 @@ function flashIssueButton(element, className) {
 function updateTicketMessage(category, message, className) {
     const numberElement = document.getElementById(`number${category}`);
     numberElement.innerText = message;
-    numberElement.classList.remove('text-success', 'text-warning', 'text-danger');
+    numberElement.classList.remove('text-info', 'text-success', 'text-warning', 'text-danger');
     numberElement.classList.add(className);
     setTimeout(() => {
         numberElement.classList.remove(className);
     }, ISSUE_BUTTON_LOCK_MS);
+}
+
+function setButtonLabel(element, label) {
+    if (!element.dataset.originalLabel) {
+        element.dataset.originalLabel = element.innerText;
+    }
+    element.innerText = label;
+}
+
+function restoreButtonLabel(element) {
+    if (element.dataset.originalLabel) {
+        element.innerText = element.dataset.originalLabel;
+    }
 }
 
 function issueTicket(element, buttonText) {
@@ -51,6 +64,10 @@ function issueTicket(element, buttonText) {
 
     const category = element.getAttribute('data-category');
     const now = new Date();
+
+    updateTicketMessage(category, '発券処理中です', 'text-info');
+    setButtonLabel(element, '発券中...');
+    flashIssueButton(element, 'ticket-feedback-processing');
 
     const japanTimeFormatter = new Intl.DateTimeFormat('ja-JP', {
         year: 'numeric',
@@ -107,5 +124,10 @@ function issueTicket(element, buttonText) {
             console.error('There was an error!', error);
             updateTicketMessage(category, '通信エラーのため発券結果を確認できませんでした', 'text-danger');
             flashIssueButton(element, 'ticket-feedback-error');
+        })
+        .finally(() => {
+            setTimeout(() => {
+                restoreButtonLabel(element);
+            }, ISSUE_BUTTON_LOCK_MS);
         });
 }

--- a/static/script.js
+++ b/static/script.js
@@ -42,19 +42,6 @@ function updateTicketMessage(category, message, className) {
     }, ISSUE_BUTTON_LOCK_MS);
 }
 
-function setButtonLabel(element, label) {
-    if (!element.dataset.originalLabel) {
-        element.dataset.originalLabel = element.innerText;
-    }
-    element.innerText = label;
-}
-
-function restoreButtonLabel(element) {
-    if (element.dataset.originalLabel) {
-        element.innerText = element.dataset.originalLabel;
-    }
-}
-
 function issueTicket(element, buttonText) {
     if (element.disabled) {
         return;
@@ -66,7 +53,6 @@ function issueTicket(element, buttonText) {
     const now = new Date();
 
     updateTicketMessage(category, '発券処理中です', 'text-info');
-    setButtonLabel(element, '発券中...');
     flashIssueButton(element, 'ticket-feedback-processing');
 
     const japanTimeFormatter = new Intl.DateTimeFormat('ja-JP', {
@@ -124,10 +110,5 @@ function issueTicket(element, buttonText) {
             console.error('There was an error!', error);
             updateTicketMessage(category, '通信エラーのため発券結果を確認できませんでした', 'text-danger');
             flashIssueButton(element, 'ticket-feedback-error');
-        })
-        .finally(() => {
-            setTimeout(() => {
-                restoreButtonLabel(element);
-            }, ISSUE_BUTTON_LOCK_MS);
         });
 }

--- a/static/script.js
+++ b/static/script.js
@@ -2,6 +2,7 @@
 // ブラウザ側での印刷コードは不要です。
 
 let selectedStaffCount = null;
+const ISSUE_BUTTON_LOCK_MS = 2000;
 
 function selectStaff(count) {
     selectedStaffCount = count;
@@ -17,7 +18,37 @@ function selectStaff(count) {
     document.getElementById('staffCountDisplay').textContent = `現在：${count}人`;
 }
 
+function setIssueButtonLocked(element) {
+    element.disabled = true;
+    setTimeout(() => {
+        element.disabled = false;
+    }, ISSUE_BUTTON_LOCK_MS);
+}
+
+function flashIssueButton(element, className) {
+    element.classList.add(className);
+    setTimeout(() => {
+        element.classList.remove(className);
+    }, ISSUE_BUTTON_LOCK_MS);
+}
+
+function updateTicketMessage(category, message, className) {
+    const numberElement = document.getElementById(`number${category}`);
+    numberElement.innerText = message;
+    numberElement.classList.remove('text-success', 'text-warning', 'text-danger');
+    numberElement.classList.add(className);
+    setTimeout(() => {
+        numberElement.classList.remove(className);
+    }, ISSUE_BUTTON_LOCK_MS);
+}
+
 function issueTicket(element, buttonText) {
+    if (element.disabled) {
+        return;
+    }
+
+    setIssueButtonLocked(element);
+
     const category = element.getAttribute('data-category');
     const now = new Date();
 
@@ -58,12 +89,23 @@ function issueTicket(element, buttonText) {
         .then(response => response.json())
         .then(data => {
             if (data.error) {
-                alert(`Error: ${data.error}`);
+                updateTicketMessage(category, `発券できませんでした: ${data.error}`, 'text-danger');
+                flashIssueButton(element, 'ticket-feedback-error');
+            } else if (data.print_ok === false) {
+                updateTicketMessage(
+                    category,
+                    `番号 ${data.next_number} を発券しました。印刷されていない可能性があります。`,
+                    'text-warning'
+                );
+                flashIssueButton(element, 'ticket-feedback-warning');
             } else {
-                document.getElementById(`number${category}`).innerText = `次の番号: ${data.next_number}`;
+                updateTicketMessage(category, `番号 ${data.next_number} を発券しました`, 'text-success');
+                flashIssueButton(element, 'ticket-feedback-success');
             }
         })
         .catch(error => {
             console.error('There was an error!', error);
+            updateTicketMessage(category, '通信エラーのため発券結果を確認できませんでした', 'text-danger');
+            flashIssueButton(element, 'ticket-feedback-error');
         });
 }

--- a/static/style.css
+++ b/static/style.css
@@ -7,6 +7,10 @@ body {
     font-size: 24px; /* テキストのサイズを大きくする */
 }
 
+.ticket-feedback-processing {
+    box-shadow: 0 0 0 .25rem rgba(23, 162, 184, .35);
+}
+
 .ticket-feedback-success {
     box-shadow: 0 0 0 .25rem rgba(40, 167, 69, .35);
 }
@@ -19,6 +23,7 @@ body {
     box-shadow: 0 0 0 .25rem rgba(220, 53, 69, .35);
 }
 
+.ticket-feedback-processing,
 .ticket-feedback-success,
 .ticket-feedback-warning,
 .ticket-feedback-error {

--- a/static/style.css
+++ b/static/style.css
@@ -7,6 +7,24 @@ body {
     font-size: 24px; /* テキストのサイズを大きくする */
 }
 
+.ticket-feedback-success {
+    box-shadow: 0 0 0 .25rem rgba(40, 167, 69, .35);
+}
+
+.ticket-feedback-warning {
+    box-shadow: 0 0 0 .25rem rgba(255, 193, 7, .45);
+}
+
+.ticket-feedback-error {
+    box-shadow: 0 0 0 .25rem rgba(220, 53, 69, .35);
+}
+
+.ticket-feedback-success,
+.ticket-feedback-warning,
+.ticket-feedback-error {
+    transition: box-shadow .15s ease-in-out;
+}
+
 /* タブレットの横向き表示に対応 */
 @media (min-width: 768px) {
     .container {
@@ -26,4 +44,3 @@ body {
     transform: scale(1.1); 
     transition: transform 0.1s;
 }
-

--- a/static/style.css
+++ b/static/style.css
@@ -7,6 +7,16 @@ body {
     font-size: 24px; /* テキストのサイズを大きくする */
 }
 
+.table.table-bordered {
+    table-layout: fixed;
+    width: 100%;
+}
+
+.table.table-bordered td {
+    width: 33.33%;
+    vertical-align: top;
+}
+
 .ticket-feedback-processing {
     box-shadow: 0 0 0 .25rem rgba(23, 162, 184, .35);
 }

--- a/test_app.py
+++ b/test_app.py
@@ -22,7 +22,7 @@ import app as app_module
 from app import app
 
 # テスト中に実機プリンターへ印刷しないよう無効化する
-app_module.print_ticket = lambda *args, **kwargs: None
+app_module.print_ticket = lambda *args, **kwargs: True
 
 
 def tearDownModule():
@@ -50,6 +50,25 @@ class FlaskTest(unittest.TestCase):
         response_data = json.loads(response.data)
         self.assertEqual(response_data['category'], 'A')
         self.assertIn('next_number', response_data)
+        self.assertTrue(response_data['print_ok'])
+
+    def test_get_next_number_returns_print_status_when_print_fails(self):
+        original_print_ticket = app_module.print_ticket
+        app_module.print_ticket = lambda *args, **kwargs: False
+        try:
+            response = self.app.post(
+                '/get_next_number',
+                data=json.dumps({'category': 'A'}),
+                content_type='application/json',
+            )
+        finally:
+            app_module.print_ticket = original_print_ticket
+
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.data)
+        self.assertEqual(response_data['category'], 'A')
+        self.assertIn('next_number', response_data)
+        self.assertFalse(response_data['print_ok'])
 
     def test_get_next_number_increments(self):
         first = json.loads(self.app.post(


### PR DESCRIPTION
## 関連Issue

Fixes #21
Partially fixes #24

## 変更概要

このPRは #21 の印刷失敗明示を実装するとともに、#24 のメンテナーコメントに基づき、押下直後の発券中表示、押下ボタンの2秒 disabled、印刷成功時の簡易明示を追加します。

## 主な変更

- `/get_next_number` のレスポンスに `print_ok` を追加
- 印刷成功時は `print_ok: true` を返す
- 印刷失敗時も発券処理は止めず、`print_ok: false` を返す
- 発券画面で押下直後に「発券処理中です」を表示
- 押下したボタンのラベルを一時的に「発券中...」へ変更
- 押下したボタンのみ2秒間 disabled
- 発券成功、印刷失敗、通信/APIエラーで表示と簡易フィードバックを分岐
- 印刷成功時にも色またはフラッシュ相当の簡易明示を追加

## 影響範囲

- queue（番号発券）
- 発券画面 `/`
- 発券API `/get_next_number`
- `app.py`
- `static/script.js`
- `static/style.css`
- `test_app.py`
- `docs/audit/CODEX_DOCKER_VERIFICATION.md`

DB スキーマ変更はありません。
既存の番号発行、DB 更新、待ち人数反映の基本挙動は維持しています。

## #24 との関係

#24 のうち、このPRでは「押したかどうか分からないことによる短時間の連打」を軽減する範囲を扱います。

完全な二重送信防止、API応答完了までのロック、サーバー側での短時間重複検知は、このPRの範囲外とします。

## 動作確認

静的確認のみです。

- `app.py` の `/get_next_number` レスポンス変更を確認
- `static/script.js` の発券中表示、2秒 disabled、成功/警告/エラー表示を確認
- `static/style.css` の発券中・成功・警告・エラー表示を確認
- `test_app.py` の印刷成功/失敗テスト追加を確認

Docker build / docker compose up / 実機プリンター / 実機タブレットでの確認は未実施です。

## AI Assistance

AIツールを使用しました。最終的な採用可否、変更範囲、PR提出内容は人間が確認しています。