### PR TITLE
Fix receipt printing garbled text on Linux/Docker by fixing encoding to cp932

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,8 +35,8 @@ PRINTER_VID    = int(os.environ.get('PRINTER_VID', '0x04b8'), 16)
 PRINTER_PID    = int(os.environ.get('PRINTER_PID', '0x0e20'), 16)
 
 
-def _build_escpos_data(category, button_text, number, timestamp_str, encoding='utf-8'):
-    """ESC/POSバイト列を組み立てる。Windows(win32print)はcp932、Linux(pyusb)はutf-8。"""
+def _build_escpos_data(category, button_text, number, timestamp_str, encoding='cp932'):
+    """ESC/POSバイト列を組み立てる。プリンター側の既定コードページ(cp932/Shift_JIS)に合わせる。"""
     ESC = b'\x1b'
     GS  = b'\x1d'
 
@@ -111,8 +111,8 @@ def print_ticket(category, button_text, number, timestamp_str):
         return
     try:
         import sys
-        encoding = 'cp932' if sys.platform == 'win32' else 'utf-8'
-        data = _build_escpos_data(category, button_text or '', number, timestamp_str or '', encoding)
+        # プリンター本体がcp932(Shift_JIS)を前提としているため、OSに関わらずcp932を使う
+        data = _build_escpos_data(category, button_text or '', number, timestamp_str or '', 'cp932')
         if sys.platform == 'win32':
             _print_windows(data)
         else:


### PR DESCRIPTION
Fixes #35

## 変更概要

レシートプリンター(POS-80C)はOSに関わらずcp932(Shift_JIS)を前提とするため、`print_ticket` のエンコーディングを `sys.platform` 判定(Windows=cp932/Linux=utf-8)から **cp932固定** に変更する。

## 変更点

- `_build_escpos_data` の既定引数を `encoding='utf-8'` → `encoding='cp932'`
- `print_ticket` 内のOS判定によるエンコーディング切り替えを廃止し、cp932固定に

## 影響範囲

- queue（番号発券）の印字処理のみ
- Windows本番：従来と同じ挙動（元々cp932だったため無変化）
- Linux/Docker実行時：文字化けが解消
- DBスキーマ・API互換・認証・通信・設定には影響なし
- 依存パッケージの追加・変更なし

## 動作確認

- WSL2 Docker環境で実機プリンター(POS-80C, USBパススルー)に印字し、修正前は文字化け・修正後は正しく印字されることを確認
- Windows実機でも印字確認（従来通り正常）

## 規定区分

軽微変更(PATCH)に該当。既存の使い方を壊さないバグ修正であり、DB/API/認証/通信/設定への影響なし、依存パッケージの変更なし、既存の業務フロー・本番運用手順に影響なし。

## AI Assistance（CONTRIBUTING準拠）

- 使用ツール：Claude（Claude Code）
- 範囲：バグの原因調査・修正実装・実機での動作確認
- 人間による動作確認：あり（実機プリンターでの印字確認）