### PR TITLE
fix: DB内部エラー時にHTTP 500を返す(4ルート)

### DIFF
--- a/app.py
+++ b/app.py
@@ -326,7 +326,7 @@ def start_processing():
             )
     except Exception as e:
         print(f"start_processing error: {e}")
-        return jsonify({'success': False, 'error': 'Internal server error'})
+        return jsonify({'success': False, 'error': 'Internal server error'}), 500
 
     return jsonify({'success': True})
 
@@ -375,7 +375,7 @@ def end_processing():
             )
     except Exception as e:
         print(f"end_processing error: {e}")
-        return jsonify({'success': False, 'error': 'Internal server error'})
+        return jsonify({'success': False, 'error': 'Internal server error'}), 500
 
     return jsonify({'success': True})
 
@@ -407,7 +407,7 @@ def cancel_processing():
                 }), 404
     except Exception as e:
         print(f"cancel_processing error: {e}")
-        return jsonify({'success': False, 'error': 'Internal server error'})
+        return jsonify({'success': False, 'error': 'Internal server error'}), 500
 
     return jsonify({'success': True})
 
@@ -446,7 +446,7 @@ def delete_ticket():
             )
     except Exception as e:
         print(f"delete_ticket error: {e}")
-        return jsonify({'success': False, 'error': 'Internal server error'})
+        return jsonify({'success': False, 'error': 'Internal server error'}), 500
 
     return jsonify({'success': True})
 

--- a/verification/REPORT.md
+++ b/verification/REPORT.md
@@ -1,0 +1,50 @@
+# DB エラー時 HTTP 500 化修正レポート
+
+**日付**: 2026-07-20
+**ブランチ**: `fix/db-error-http-500-only`
+**対象PR**: #5
+**修正対象**: `app.py` (4ルート)
+
+---
+
+## 1. 概要
+
+DB エラー発生時に HTTP 200 でレスポンスを返していた4ルートを、HTTP 500 を返すよう修正した。
+
+**修正対象外**: `/display_data` は別ブランチ (`fix/db-error-http-status`) でキャッシュ機構を導入する方針。
+
+## 2. 修正内容
+
+各ルートの `except` ブロックの `return jsonify({...})` に第二引数 `500` を追加。
+
+| ルート | 修正箇所 |
+|--------|---------|
+| `/start_processing` | L329 |
+| `/end_processing` | L378 |
+| `/cancel_processing` | L410 |
+| `/delete_ticket` | L449 |
+
+`/get_next_number` は既に HTTP 500 を返していたため修正不要。
+
+## 3. 動作確認結果
+
+**テスト手法**: Flask テストクライアント使用。`DB_PATH` を存在しないディレクトリに設定し `sqlite3.OperationalError` を発火。
+
+| テストケース | 期待値 | 実測値 | 結果 |
+|-------------|--------|--------|------|
+| `/get_next_number` (入力エラー) | 400 | 400 | PASS |
+| `/get_next_number` (DB エラー) | 500 | 500 | PASS |
+| `/start_processing` (DB エラー) | 500 | 500 | PASS |
+| `/end_processing` (DB エラー) | 500 | 500 | PASS |
+| `/cancel_processing` (DB エラー) | 500 | 500 | PASS |
+| `/delete_ticket` (DB エラー) | 500 | 500 | PASS |
+| `/display_data` (DB エラー, 変更なし) | 200 | 200 | PASS |
+
+**全7テスト通過**
+
+## 4. ファイル一覧
+
+| ファイル | 変更種別 |
+|---------|---------|
+| `app.py` | 修正 (4箇所) |
+| `verification/test_db_error_status.py` | 修正 (500化ルートのみテスト) |

--- a/verification/test_db_error_status.py
+++ b/verification/test_db_error_status.py
@@ -1,0 +1,126 @@
+"""
+DB エラー時の HTTP ステータスコード検証スクリプト (500化対象ルートのみ)
+
+修正対象: /start_processing, /end_processing, /cancel_processing, /delete_ticket
+修正内容: DBエラー時に HTTP 200 → HTTP 500
+
+検証対象外: /display_data (別ブランチで対応)
+"""
+import os
+import sys
+import json
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ['DB_PATH'] = os.path.join(tempfile.gettempdir(), '__nonexistent_mado_test__', 'no.db')
+os.environ['CORS_ORIGINS'] = '*'
+
+from app import app
+
+
+TESTS = [
+    {
+        'name': '/get_next_number (missing category)',
+        'method': 'post',
+        'path': '/get_next_number',
+        'json': {},
+        'expect_status': 400,
+    },
+    {
+        'name': '/get_next_number (valid input, DB error)',
+        'method': 'post',
+        'path': '/get_next_number',
+        'json': {'category': 'A', 'buttonText': 'test'},
+        'expect_status': 500,
+    },
+    {
+        'name': '/start_processing (DB error)',
+        'method': 'post',
+        'path': '/start_processing',
+        'json': {'ticket_number': 1, 'category': 'A'},
+        'expect_status': 500,
+    },
+    {
+        'name': '/end_processing (DB error)',
+        'method': 'post',
+        'path': '/end_processing',
+        'json': {'ticket_number': 1},
+        'expect_status': 500,
+    },
+    {
+        'name': '/cancel_processing (DB error)',
+        'method': 'post',
+        'path': '/cancel_processing',
+        'json': {'ticket_number': 1},
+        'expect_status': 500,
+    },
+    {
+        'name': '/delete_ticket (DB error)',
+        'method': 'post',
+        'path': '/delete_ticket',
+        'json': {'ticket_number': 1, 'category': 'A'},
+        'expect_status': 500,
+    },
+    {
+        'name': '/display_data (DB error, unchanged)',
+        'method': 'get',
+        'path': '/display_data',
+        'json': None,
+        'expect_status': 200,
+    },
+]
+
+
+def run_tests():
+    client = app.test_client()
+    results = []
+    for t in TESTS:
+        if t['method'] == 'post':
+            resp = client.post(
+                t['path'],
+                data=json.dumps(t['json'] or {}),
+                content_type='application/json',
+            )
+        else:
+            resp = client.get(t['path'])
+
+        actual = resp.status_code
+        passed = actual == t['expect_status']
+        body = ''
+        if not passed:
+            try:
+                body = resp.get_data(as_text=True)[:200]
+            except Exception:
+                body = '<unreadable>'
+        results.append({
+            'name': t['name'],
+            'expected': t['expect_status'],
+            'actual': actual,
+            'passed': passed,
+            'body': body,
+        })
+    return results
+
+
+def main():
+    results = run_tests()
+
+    all_pass = all(r['passed'] for r in results)
+    print('=' * 70)
+    print('DB Error HTTP Status Code Verification (500-only branch)')
+    print('=' * 70)
+    for r in results:
+        mark = 'PASS' if r['passed'] else 'FAIL'
+        print(f"  [{mark}] {r['name']}: expected={r['expected']}, actual={r['actual']}")
+        if r['body']:
+            print(f"         body: {r['body'][:150]}")
+    print('-' * 70)
+    print(f"Result: {'ALL PASSED' if all_pass else 'SOME FAILED'}")
+    print('=' * 70)
+    return all_pass, results
+
+
+if __name__ == '__main__':
+    ok, results = main()
+    sys.exit(0 if ok else 1)


### PR DESCRIPTION
/start_processing, /end_processing, /cancel_processing, /delete_ticket で DBエラー発生時にHTTP 200を返していた問題を修正。500を返すよう統一。
/display_data は対象外(別issue #5で対応予定)。

---

## 関連Issue
Fixes #4

---

## 変更種別
- [x] バグ修正
- [ ] ドキュメントのみの変更
- [ ] 軽微な文言・UI修正
- [ ] 新機能追加
- [ ] 仕様変更（破壊的変更を含む）

---

## AI Assistance
- [x] AIツールを使用した
  - 使用ツール：Claude (Cowork)
  - 利用した範囲：実装差分のレビュー・検証(git状態の確認、コード差分の確認、テストロジックの妥当性確認)

---

## 動作確認
- [x] ローカル環境で動作確認済み

確認した手順：
Flaskテストクライアントを使用し、`DB_PATH` を存在しないディレクトリに設定して `sqlite3.OperationalError` を発生させ、4ルート＋`/get_next_number`＋`/display_data`(無変更確認用)の計7ケースを検証。

確認した内容：
`/start_processing`, `/end_processing`, `/cancel_processing`, `/delete_ticket` がDBエラー時にHTTP 500を返すこと。`/display_data` は変更対象外のためHTTP 200のままであることも確認。全7テストPASS。

---

## 影響範囲
このPRが影響するパッケージ・画面・API：

`queue`パッケージ `app.py` 内の4 API(`/start_processing`, `/end_processing`, `/cancel_processing`, `/delete_ticket`)。フロントエンド(`syori.html`)は既に `success` フィールドでエラー判定しているため表示への影響なし。ステータスコードのみの変更。
