### PR TITLE
docs: ARCHITECTURE.mdのCORS設定記述を実装に合わせて修正

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,7 +53,7 @@ MADO-queue/
 | ホスト | 0.0.0.0（全インターフェース） |
 | ポート | 8000 |
 | 起動コマンド | `waitress-serve --host=0.0.0.0 --port=8000 app:app` |
-| CORS | 全ドメイン許可（flask-cors デフォルト設定） |
+| CORS | `CORS_ORIGINS` 環境変数で指定（カンマ区切り）。未指定時は `http://localhost:8000` のみ許可 |
 
 ---
 


### PR DESCRIPTION
## 変更概要

`docs/ARCHITECTURE.md` の CORS 設定の記述が、実装と逆の内容になっていたため修正する。

- 現在の記述: 「全ドメイン許可（flask-cors デフォルト設定）」
- 実際の実装（app.py:23-24）: `CORS_ORIGINS` 環境変数を読み、未指定時は `http://localhost:8000` のみ許可
- Docker本番運用でも `CORS_ORIGINS` は設定されておらず、デフォルトの `localhost:8000` 限定のまま運用されている

コード側の変更は無く、ドキュメントの記述を実態に合わせるのみ。

## 関連Issue

Part of #25

（Issue #25 の論点2「CORS設定について」に対応。論点1（ticket_number/processing_id）は PR #3 の結論待ちのため対象外）

## 変更点

- `docs/ARCHITECTURE.md`: CORS の行を実装（デフォルト値・環境変数による変更方法）に合わせて修正

## 動作確認

コード変更なし（ドキュメントのみ）のため、`app.py` の該当箇所を目視確認済み。

## AI Assistance

- 使用ツール: Claude Code
- 利用範囲: コードとドキュメントの差分調査、修正文言の作成
- 人間による確認: あり