### PR TITLE
docs: ARCHITECTURE.mdにevent_log_id後方互換の補足を追記

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,6 +110,12 @@ MADO-queue/
 | staff_count | INTEGER | YES | 処理時の職員数 |
 | event_log_id | INTEGER | YES | event_logs.id への外部参照 |
 
+> **NULL の意味（後方互換）:** `event_log_id` は移行時に `ALTER TABLE` で後付けしたカラムのため、
+> 移行前から存在する過去の処理記録では NULL のままになる。待ち一覧の判定
+> （`_WAITING_LIST_SQL`）は「`event_log_id` があればそれで判定、なければ
+> `ticket_number` + `category` で判定」という新旧両対応の OR 条件になっており、
+> これは意図的な後方互換処理である。誤って削除しないこと。
+
 ---
 
 ## 3. API仕様


### PR DESCRIPTION
## 変更概要

`docs/ARCHITECTURE.md` の `event_log_id` カラムの説明に、NULL 時の後方互換ロジックについての補足を追加する。

`processing_logs.event_log_id` は移行時に `ALTER TABLE` で後付けしたカラムのため、移行前の既存レコードは NULL のまま残る。`_WAITING_LIST_SQL`（app.py:169-186）はこれを前提に、`event_log_id` がある新形式と、`ticket_number` + `category` で判定する旧形式の両方に対応する OR 条件になっている（意図的な設計）。

この経緯がドキュメント化されていなかったため、将来のメンテナーが「冗長なOR条件」と誤解して削除してしまうリスクがあった。

コード側の変更は無く、ドキュメントへの補足のみ。

## 関連Issue

Part of #25

（Issue #25 の論点3「event_log_id なし旧形式データの互換について」に対応。論点1（ticket_number/processing_id）は PR #3 の結論待ちのため対象外）

## 変更点

- `docs/ARCHITECTURE.md`: `event_log_id` カラムの説明に、NULL 時の後方互換ロジックの補足を追加

## 動作確認

コード変更なし（ドキュメントのみ）のため、`app.py`・`safe_migrate_db.py` の該当箇所を目視確認済み。

## AI Assistance

- 使用ツール: Claude Code
- 利用範囲: コードの後方互換ロジックの調査、補足文言の作成
- 人間による確認: あり