### PR TITLE
refactor: プリンターコードを printer.py に分離

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ from flask import Flask, jsonify, request, render_template
 from flask_cors import CORS
 
 from config import CATEGORY_START
+from printer import print_ticket
 
 app = Flask(__name__)
 _cors_origins = os.environ.get('CORS_ORIGINS', 'http://localhost:8000').split(',')
@@ -25,104 +26,6 @@ CORS(app, origins=_cors_origins)
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DB_PATH = os.environ.get('DB_PATH', os.path.join(BASE_DIR, 'numbers.db'))
-
-# ---------------------------------------------------------------------------
-# レシートプリンター
-# ---------------------------------------------------------------------------
-
-PRINTER_NAME   = os.environ.get('PRINTER_NAME',   'POS-80C (copy 1)')
-PRINTER_VID    = int(os.environ.get('PRINTER_VID', '0x04b8'), 16)
-PRINTER_PID    = int(os.environ.get('PRINTER_PID', '0x0e20'), 16)
-
-
-def _build_escpos_data(category, button_text, number, timestamp_str, encoding='cp932'):
-    """ESC/POSバイト列を組み立てる。プリンター側の既定コードページ(cp932/Shift_JIS)に合わせる。"""
-    ESC = b'\x1b'
-    GS  = b'\x1d'
-
-    def s(text):
-        return text.encode(encoding, errors='replace')
-
-    try:
-        dt = datetime.fromisoformat(timestamp_str)
-        formatted_time = dt.strftime('%m.%d-%H:%M:%S')
-    except Exception:
-        formatted_time = timestamp_str or ''
-
-    data  = ESC + b'@'            # 初期化
-    data += ESC + b'a\x01'        # 中央揃え
-    data += GS  + b'!\x01'        # 縦2倍
-    data += s(f'カテゴリ: {category}\n')
-    data += s(f'用途: {button_text}\n\n')
-    data += s(f'日時: {formatted_time}\n\n')
-    data += GS  + b'!\x33'        # 縦横4倍
-    data += s(f'番号: {number}\n\n')
-    data += GS  + b'!\x00'        # 通常サイズに戻す
-    if category != 'A':
-        data += s('カテゴリAの方を先に\nご案内する場合があります\n')
-    data += GS + b'V\x41\x30'     # 48ドット送ってからカット
-    return data
-
-
-def _print_windows(data):
-    """Windows: win32print でRAW送信（2枚）"""
-    import win32print
-    for copy in range(2):
-        h = win32print.OpenPrinter(PRINTER_NAME)
-        try:
-            win32print.StartDocPrinter(h, 1, (f'ticket-{copy+1}', None, 'RAW'))
-            try:
-                win32print.StartPagePrinter(h)
-                win32print.WritePrinter(h, data)
-                win32print.EndPagePrinter(h)
-            finally:
-                win32print.EndDocPrinter(h)
-        finally:
-            win32print.ClosePrinter(h)
-
-
-_usb_dev = None  # USB デバイスのシングルトン（起動時に一度だけ初期化）
-
-
-def _get_usb_dev():
-    """USB プリンターデバイスを返す。初回のみ find + set_configuration() を実行する。"""
-    global _usb_dev
-    if _usb_dev is None:
-        import usb.core
-        dev = usb.core.find(idVendor=PRINTER_VID, idProduct=PRINTER_PID)
-        if dev is None:
-            raise RuntimeError(
-                f'プリンターが見つかりません (VID={PRINTER_VID:#06x} PID={PRINTER_PID:#06x})'
-            )
-        dev.set_configuration()  # 初回のみ実行（毎回呼ぶとUSBリセットが発生する）
-        _usb_dev = dev
-    return _usb_dev
-
-
-def _print_linux(data):
-    """Linux: pyusb でUSB直接送信（2枚）"""
-    dev = _get_usb_dev()
-    for _ in range(2):
-        dev.write(1, data)
-
-def print_ticket(category, button_text, number, timestamp_str):
-    """レシートプリンターにチケットを印刷する。カテゴリDは印刷せず成功扱いにする。"""
-    if category == 'D':
-        return True
-    try:
-        import sys
-        # プリンター本体がcp932(Shift_JIS)を前提としているため、OSに関わらずcp932を使う
-        data = _build_escpos_data(category, button_text or '', number, timestamp_str or '', 'cp932')
-        if sys.platform == 'win32':
-            _print_windows(data)
-        else:
-            _print_linux(data)
-        print(f'[print_ticket] 印刷完了: カテゴリ={category} 番号={number}')
-        return True
-    except Exception as e:
-        print(f'[print_ticket] error: {e}')
-        return False
-
 
 # ---------------------------------------------------------------------------
 # DB ヘルパー

--- a/printer.py
+++ b/printer.py
@@ -1,0 +1,123 @@
+"""
+printer.py — レシートプリンターモジュール
+
+ESC/POSバイト列の構築と印刷を担当する。
+app.py から分離し、保守性を向上させる。
+"""
+
+from datetime import datetime
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# 設定
+# ---------------------------------------------------------------------------
+
+PRINTER_NAME = os.environ.get('PRINTER_NAME', 'POS-80C (copy 1)')
+PRINTER_VID = int(os.environ.get('PRINTER_VID', '0x04b8'), 16)
+PRINTER_PID = int(os.environ.get('PRINTER_PID', '0x0e20'), 16)
+
+
+# ---------------------------------------------------------------------------
+# ESC/POS データ構築
+# ---------------------------------------------------------------------------
+
+def _build_escpos_data(category, button_text, number, timestamp_str, encoding='cp932'):
+    """ESC/POSバイト列を組み立てる。プリンター側の既定コードページ(cp932/Shift_JIS)に合わせる。"""
+    ESC = b'\x1b'
+    GS = b'\x1d'
+
+    def s(text):
+        return text.encode(encoding, errors='replace')
+
+    try:
+        dt = datetime.fromisoformat(timestamp_str)
+        formatted_time = dt.strftime('%m.%d-%H:%M:%S')
+    except Exception:
+        formatted_time = timestamp_str or ''
+
+    data = ESC + b'@'            # 初期化
+    data += ESC + b'a\x01'        # 中央揃え
+    data += GS + b'!\x01'        # 縦2倍
+    data += s(f'カテゴリ: {category}\n')
+    data += s(f'用途: {button_text}\n\n')
+    data += s(f'日時: {formatted_time}\n\n')
+    data += GS + b'!\x33'        # 縦横4倍
+    data += s(f'番号: {number}\n\n')
+    data += GS + b'!\x00'        # 通常サイズに戻す
+    if category != 'A':
+        data += s('カテゴリAの方を先に\nご案内する場合があります\n')
+    data += GS + b'V\x41\x30'     # 48ドット送ってからカット
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Windows 印刷
+# ---------------------------------------------------------------------------
+
+def _print_windows(data):
+    """Windows: win32print でRAW送信（2枚）"""
+    import win32print
+    for copy in range(2):
+        h = win32print.OpenPrinter(PRINTER_NAME)
+        try:
+            win32print.StartDocPrinter(h, 1, (f'ticket-{copy+1}', None, 'RAW'))
+            try:
+                win32print.StartPagePrinter(h)
+                win32print.WritePrinter(h, data)
+                win32print.EndPagePrinter(h)
+            finally:
+                win32print.EndDocPrinter(h)
+        finally:
+            win32print.ClosePrinter(h)
+
+
+# ---------------------------------------------------------------------------
+# Linux 印刷
+# ---------------------------------------------------------------------------
+
+_usb_dev = None  # USB デバイスのシングルトン（起動時に一度だけ初期化）
+
+
+def _get_usb_dev():
+    """USB プリンターデバイスを返す。初回のみ find + set_configuration() を実行する。"""
+    global _usb_dev
+    if _usb_dev is None:
+        import usb.core
+        dev = usb.core.find(idVendor=PRINTER_VID, idProduct=PRINTER_PID)
+        if dev is None:
+            raise RuntimeError(
+                f'プリンターが見つかりません (VID={PRINTER_VID:#06x} PID={PRINTER_PID:#06x})'
+            )
+        dev.set_configuration()  # 初回のみ実行（毎回呼ぶとUSBリセットが発生する）
+        _usb_dev = dev
+    return _usb_dev
+
+
+def _print_linux(data):
+    """Linux: pyusb でUSB直接送信（2枚）"""
+    dev = _get_usb_dev()
+    for _ in range(2):
+        dev.write(1, data)
+
+
+# ---------------------------------------------------------------------------
+# メインエントリ
+# ---------------------------------------------------------------------------
+
+def print_ticket(category, button_text, number, timestamp_str):
+    """レシートプリンターにチケットを印刷する。カテゴリDは印刷せず成功扱いにする。"""
+    if category == 'D':
+        return True
+    try:
+        # プリンター本体がcp932(Shift_JIS)を前提としているため、OSに関わらずcp932を使う
+        data = _build_escpos_data(category, button_text or '', number, timestamp_str or '', 'cp932')
+        if sys.platform == 'win32':
+            _print_windows(data)
+        else:
+            _print_linux(data)
+        print(f'[print_ticket] 印刷完了: カテゴリ={category} 番号={number}')
+        return True
+    except Exception as e:
+        print(f'[print_ticket] error: {e}')
+        return False


### PR DESCRIPTION
## Summary

`app.py` に混在していたレシートプリンター処理を `printer.py` に分離します。
**外部動作の変更はありません**（pure refactor）。

- `printer.py` を新規作成
  - `_build_escpos_data` / `_print_windows` / `_get_usb_dev` / `_print_linux` / `print_ticket`
  - `PRINTER_NAME` / `PRINTER_VID` / `PRINTER_PID`（環境変数の既定値も従来どおり）
- `app.py` は `from printer import print_ticket` のみ利用

## Related

- Related to #44

## 変更しないもの

- 印刷枚数（2枚）
- ESC/POS コマンド仕様
- 環境変数名・既定値
- カテゴリ D は印刷しない挙動
- 印刷失敗時の例外握りつぶし（発券自体は成功する設計）

## Test plan

- [x] `python -m unittest test_app -v` がパスすること
- [x] プリンター未接続環境で `import printer` が可能であること
- [x] `print_ticket` のシグネチャが従来どおりであること
- [ ] （任意）実機プリンターでの印刷確認

## AI Assistance

- 使用ツール: Claude / Grok
- 範囲: 設計に沿ったコード分離
- 動作確認: ユニットテスト・静的 import 確認済み。実機印刷は未実施